### PR TITLE
Fix style immanent locales

### DIFF
--- a/features/step_definitions/renderer.rb
+++ b/features/step_definitions/renderer.rb
@@ -15,8 +15,13 @@ Given(/^the following macro:$/) do |string|
   @macro = CSL.parse!(string, CSL::Style)
 end
 
+Given(/^the "(.*?)" locale$/) do |locale|
+  @locale = locale
+end
+
 When(/^I render the following citation items as "(.*?)":$/) do |format, items|
-  r = CiteProc::Ruby::Renderer.new(:format => format)
+  @locale ||= 'en'
+  r = CiteProc::Ruby::Renderer.new(:format => format, :locale => @locale)
 
   @results = items.hashes.map.with_index do |data, idx|
     i = CiteProc::CitationItem.new(:id => "ID-#{idx}")

--- a/features/style_immanent_locale_terms.feature
+++ b/features/style_immanent_locale_terms.feature
@@ -3,7 +3,7 @@ Feature: Rendering bibliography nodes
   I want to render citation items
   Using bibliography nodes
 
-  Scenario: Rendering APA style bibliographies as text
+  Scenario: Rendering APA style bibliographies as text in English
     Given the "apa-with-different-translations" style's bibliography node
     When I render the following citation items as "text":
       | type            | author           | title                 | issued           | translator             | container-title     | page   | issue |
@@ -12,3 +12,25 @@ Feature: Rendering bibliography nodes
     Then the results should be:
       | Pynchon, T. (2006). The crying of lot 49. In H. Hard (Who translated this piece on her/his own), . |
       | Derrida, J. (1975). The purveyor of truth. In J. Harder (Who translated this piece on her/his own), Yale French Studies (pp. 31–113). |
+
+  Scenario: Rendering APA style bibliographies as text in French
+    Given the "apa-with-different-translations" style's bibliography node
+    Given the "fr" locale
+    When I render the following citation items as "text":
+      | type            | author           | title                 | issued           | translator             | container-title     | page   | issue |
+      | paper-conference            | Thomas Pynchon   | The crying of lot 49  | July 7, 2006 | Harald Hard        |                     |        |       |
+      | paper-conference | Derrida, Jacques | The purveyor of truth | 1975             | Jina Harder        | Yale French Studies | 31-113 | 52    |
+    Then the results should be:
+      | Pynchon, T. (2006). The crying of lot 49. In H. Hard (Le merveilleux traducteur), . |
+      | Derrida, J. (1975). The purveyor of truth. In J. Harder (Le merveilleux traducteur), Yale French Studies (p. 31‑113). |
+
+  Scenario: Rendering APA style bibliographies as text in German (a language where the style has no explicit terms for)
+    Given the "apa-with-different-translations" style's bibliography node
+    Given the "de" locale
+    When I render the following citation items as "text":
+      | type            | author           | title                 | issued           | translator             | container-title     | page   | issue |
+      | paper-conference            | Thomas Pynchon   | The crying of lot 49  | July 7, 2006 | Harald Hard        |                     |        |       |
+      | paper-conference | Derrida, Jacques | The purveyor of truth | 1975             | Jina Harder        | Yale French Studies | 31-113 | 52    |
+    Then the results should be:
+      | Pynchon, T. (2006). The crying of lot 49. In H. Hard (Übers.), . |
+      | Derrida, J. (1975). The purveyor of truth. In J. Harder (Übers.), Yale French Studies (S. 31–113). |

--- a/features/style_immanent_locale_terms.feature
+++ b/features/style_immanent_locale_terms.feature
@@ -1,0 +1,14 @@
+Feature: Rendering bibliography nodes
+  As a hacker of cite processors
+  I want to render citation items
+  Using bibliography nodes
+
+  Scenario: Rendering APA style bibliographies as text
+    Given the "apa-with-different-translations" style's bibliography node
+    When I render the following citation items as "text":
+      | type            | author           | title                 | issued           | translator             | container-title     | page   | issue |
+      | paper-conference            | Thomas Pynchon   | The crying of lot 49  | July 7, 2006 | Harald Hard        |                     |        |       |
+      | paper-conference | Derrida, Jacques | The purveyor of truth | 1975             | Jina Harder        | Yale French Studies | 31-113 | 52    |
+    Then the results should be:
+      | Pynchon, T. (2006). The crying of lot 49. In H. Hard (Who translated this piece on her/his own), . |
+      | Derrida, J. (1975). The purveyor of truth. In J. Harder (Who translated this piece on her/his own), Yale French Studies (pp. 31–113). |

--- a/lib/citeproc/ruby/format.rb
+++ b/lib/citeproc/ruby/format.rb
@@ -231,13 +231,16 @@ module CiteProc
 
           # TODO exceptions: word followed by colon
           first = true
-          output.gsub!(/\b(\p{Ll})(\p{L}+)\b/) do |word|
-            if Format.stopword?(word) and not first
-              word
-            else
-              first = false
-              "#{CiteProc.upcase($1)}#{$2}"
+          # output.gsub!(/\b(\p{Ll})(\p{L}+)\b/) do |word|
+          output.gsub!(/\b(\p{L})(\p{L}+)\b/) do |word|
+            first_letter = $1
+            rest_of_word = $2
+            result = word
+            if first_letter.match(/^\p{Ll}/) && (!Format.stopword?(word) || first)
+              result = "#{CiteProc.upcase(first_letter)}#{rest_of_word}"
             end
+            first = false
+            result
           end
           output.gsub!(/\b(\p{Ll})(\p{L}+)\b$/) { "#{CiteProc.upcase($1)}#{$2}" }
 

--- a/lib/citeproc/ruby/renderer.rb
+++ b/lib/citeproc/ruby/renderer.rb
@@ -50,6 +50,8 @@ module CiteProc
         raise ArgumentError, "#{specialize} not implemented" unless
           respond_to?(specialize, true)
 
+        merge_locale_with_style_locale!(node)
+
         format! send(specialize, item, node), node
       end
 

--- a/lib/citeproc/ruby/renderer/locale.rb
+++ b/lib/citeproc/ruby/renderer/locale.rb
@@ -27,15 +27,16 @@ module CiteProc
           @merged_locales.compare_by_identity
         end
 
-        return if @merged_locales[@locale]
-
         style = node.root
         return unless style.respond_to?(:locales)
+
+        return if @merged_locales[@locale] && @merged_locales[@locale].include?(style)
 
         matching_locale_in_style = style.locales.detect { |l| l == @locale }
         if matching_locale_in_style
           @locale = matching_locale_in_style.merge(@locale)
-          @merged_locales[@locale] = true
+          @merged_locales[@locale] ||= []
+          @merged_locales[@locale] << style
         end
       end
 

--- a/lib/citeproc/ruby/renderer/locale.rb
+++ b/lib/citeproc/ruby/renderer/locale.rb
@@ -20,6 +20,25 @@ module CiteProc
         locale.ordinalize(number, options)
       end
 
+      def merge_locale_with_style_locale!(node)
+        return unless node
+        unless @merged_locales
+          @merged_locales = {}
+          @merged_locales.compare_by_identity
+        end
+
+        return if @merged_locales[@locale]
+
+        style = node.root
+        return unless style.respond_to?(:locales)
+
+        matching_locale_in_style = style.locales.detect { |l| l == @locale }
+        if matching_locale_in_style
+          @locale = matching_locale_in_style.merge(@locale)
+          @merged_locales[@locale] = true
+        end
+      end
+
     end
 
   end

--- a/spec/citeproc/ruby/formats/default_spec.rb
+++ b/spec/citeproc/ruby/formats/default_spec.rb
@@ -111,6 +111,7 @@ module CiteProc
           expect(format.apply('history of the word the', node)).to eq('History of the Word The')
           expect(format.apply('faster than the speed of sound', node)).to eq('Faster than the Speed of Sound')
           expect(format.apply('on the drug-resistance of enteric bacteria', node)).to eq('On the Drug-Resistance of Enteric Bacteria')
+          expect(format.apply("The Mote in God's eye", node)).to eq("The Mote in God's Eye")
         end
       end
 

--- a/spec/citeproc/ruby/formats/default_spec.rb
+++ b/spec/citeproc/ruby/formats/default_spec.rb
@@ -112,6 +112,7 @@ module CiteProc
           expect(format.apply('faster than the speed of sound', node)).to eq('Faster than the Speed of Sound')
           expect(format.apply('on the drug-resistance of enteric bacteria', node)).to eq('On the Drug-Resistance of Enteric Bacteria')
           expect(format.apply("The Mote in God's eye", node)).to eq("The Mote in God's Eye")
+          expect(format.apply("The Mote in God eye", node)).to eq("The Mote in God Eye")
         end
       end
 

--- a/spec/citeproc/ruby/formats/default_spec.rb
+++ b/spec/citeproc/ruby/formats/default_spec.rb
@@ -113,6 +113,8 @@ module CiteProc
           expect(format.apply('on the drug-resistance of enteric bacteria', node)).to eq('On the Drug-Resistance of Enteric Bacteria')
           expect(format.apply("The Mote in God's eye", node)).to eq("The Mote in God's Eye")
           expect(format.apply("The Mote in God eye", node)).to eq("The Mote in God Eye")
+          expect(format.apply("Music community mourns death of one of its leaders", node)).to eq("Music Community Mourns Death of One of Its Leaders")
+          expect(format.apply("Pride and Prejudice", node)).to eq("Pride and Prejudice")
         end
       end
 

--- a/spec/fixtures/locales/locales-de-DE.xml
+++ b/spec/fixtures/locales/locales-de-DE.xml
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="utf-8"?>
+<locale xmlns="http://purl.org/net/xbiblio/csl" version="1.0" xml:lang="de-DE">
+  <info>
+    <rights license="http://creativecommons.org/licenses/by-sa/3.0/">This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License</rights>
+    <updated>2012-07-04T23:31:02+00:00</updated>
+  </info>
+  <style-options punctuation-in-quote="false"/>
+  <date form="text">
+    <date-part name="day" suffix=". "/>
+    <date-part name="month" suffix=" "/>
+    <date-part name="year"/>
+  </date>
+  <date form="numeric">
+    <date-part name="day" form="numeric-leading-zeros" suffix="."/>
+    <date-part name="month" form="numeric-leading-zeros" suffix="."/>
+    <date-part name="year"/>
+  </date>
+  <terms>
+    <term name="accessed">zugegriffen</term>
+    <term name="and">und</term>
+    <term name="and others">und andere</term>
+    <term name="anonymous">ohne Autor</term>
+    <term name="anonymous" form="short">o. A.</term>
+    <term name="at">auf</term>
+    <term name="available at">verfügbar unter</term>
+    <term name="by">von</term>
+    <term name="circa">circa</term>
+    <term name="circa" form="short">ca.</term>
+    <term name="cited">zitiert</term>
+    <term name="edition">
+      <single>Auflage</single>
+      <multiple>Auflagen</multiple>
+    </term>
+    <term name="edition" form="short">Aufl.</term>
+    <term name="et-al">u. a.</term>
+    <term name="forthcoming">i. E.</term>
+    <term name="from">von</term>
+    <term name="ibid">ebd.</term>
+    <term name="in">in</term>
+    <term name="in press">im Druck</term>
+    <term name="internet">Internet</term>
+    <term name="interview">Interview</term>
+    <term name="letter">Brief</term>
+    <term name="no date">ohne Datum</term>
+    <term name="no date" form="short">o. J.</term>
+    <term name="online">online</term>
+    <term name="presented at">gehalten auf der</term>
+    <term name="reference">
+      <single>Referenz</single>
+      <multiple>Referenzen</multiple>
+    </term>
+    <term name="reference" form="short">
+      <single>Ref.</single>
+      <multiple>Ref.</multiple>
+    </term>
+    <term name="retrieved">abgerufen</term>
+    <term name="scale">Maßstab</term>
+    <term name="version">Version</term>
+
+    <!-- ANNO DOMINI; BEFORE CHRIST -->
+    <term name="ad">n. Chr.</term>
+    <term name="bc">v. Chr.</term>
+
+    <!-- PUNCTUATION -->
+    <term name="open-quote">„</term>
+    <term name="close-quote">“</term>
+    <term name="open-inner-quote">‚</term>
+    <term name="close-inner-quote">‘</term>
+    <term name="page-range-delimiter">–</term>
+
+    <!-- ORDINALS -->
+    <term name="ordinal">.</term>
+
+    <!-- LONG ORDINALS -->
+    <term name="long-ordinal-01">erster</term>
+    <term name="long-ordinal-02">zweiter</term>
+    <term name="long-ordinal-03">dritter</term>
+    <term name="long-ordinal-04">vierter</term>
+    <term name="long-ordinal-05">fünfter</term>
+    <term name="long-ordinal-06">sechster</term>
+    <term name="long-ordinal-07">siebter</term>
+    <term name="long-ordinal-08">achter</term>
+    <term name="long-ordinal-09">neunter</term>
+    <term name="long-ordinal-10">zehnter</term>
+
+    <!-- LONG LOCATOR FORMS -->
+    <term name="book">
+      <single>Buch</single>
+      <multiple>Bücher</multiple>
+    </term>
+    <term name="chapter">
+      <single>Kapitel</single>
+      <multiple>Kapitel</multiple>
+    </term>
+    <term name="column">
+      <single>Spalte</single>
+      <multiple>Spalten</multiple>
+    </term>
+    <term name="figure">
+      <single>Abbildung</single>
+      <multiple>Abbildungen</multiple>
+    </term>
+    <term name="folio">
+      <single>Blatt</single>
+      <multiple>Blätter</multiple>
+    </term>
+    <term name="issue">
+      <single>Nummer</single>
+      <multiple>Nummern</multiple>
+    </term>
+    <term name="line">
+      <single>Zeile</single>
+      <multiple>Zeilen</multiple>
+    </term>
+    <term name="note">
+      <single>Note</single>
+      <multiple>Noten</multiple>
+    </term>
+    <term name="opus">
+      <single>Opus</single>
+      <multiple>Opera</multiple>
+    </term>
+    <term name="page">
+      <single>Seite</single>
+      <multiple>Seiten</multiple>
+    </term>
+    <term name="paragraph">
+      <single>Absatz</single>
+      <multiple>Absätze</multiple>
+    </term>
+    <term name="part">
+      <single>Teil</single>
+      <multiple>Teile</multiple>
+    </term>
+    <term name="section">
+      <single>Abschnitt</single>
+      <multiple>Abschnitte</multiple>
+    </term>
+    <term name="sub verbo">
+      <single>sub verbo</single>
+      <multiple>sub verbis</multiple>
+    </term>
+    <term name="verse">
+      <single>Vers</single>
+      <multiple>Verse</multiple>
+    </term>
+    <term name="volume">
+      <single>Band</single>
+      <multiple>Bände</multiple>
+    </term>
+
+    <!-- SHORT LOCATOR FORMS -->
+    <term name="book" form="short">B.</term>
+    <term name="chapter" form="short">Kap.</term>
+    <term name="column" form="short">Sp.</term>
+    <term name="figure" form="short">Abb.</term>
+    <term name="folio" form="short">Fol.</term>
+    <term name="issue" form="short">Nr.</term>
+    <term name="line" form="short">l.</term>
+    <term name="note" form="short">n.</term>
+    <term name="opus" form="short">op.</term>
+    <term name="page" form="short">
+      <single>S.</single>
+      <multiple>S.</multiple>
+    </term>
+    <term name="paragraph" form="short">Abs.</term>
+    <term name="part" form="short">Teil</term>
+    <term name="section" form="short">Abschn.</term>
+    <term name="sub verbo" form="short">
+      <single>s.v.</single>
+      <multiple>s.vv.</multiple>
+    </term>
+    <term name="verse" form="short">
+      <single>V.</single>
+      <multiple>V.</multiple>
+    </term>
+    <term name="volume" form="short">
+      <single>Bd.</single>
+      <multiple>Bd.</multiple>
+    </term>
+
+    <!-- SYMBOL LOCATOR FORMS -->
+    <term name="paragraph" form="symbol">
+      <single>¶</single>
+      <multiple>¶¶</multiple>
+    </term>
+    <term name="section" form="symbol">
+      <single>§</single>
+      <multiple>§§</multiple>
+    </term>
+
+    <!-- LONG ROLE FORMS -->
+    <term name="director">
+      <single>Regisseur</single>
+      <multiple>Regisseure</multiple>
+    </term>
+    <term name="editor">
+      <single>Herausgeber</single>
+      <multiple>Herausgeber</multiple>
+    </term>
+    <term name="editorial-director">
+      <single>Herausgeber</single>
+      <multiple>Herausgeber</multiple>
+    </term>
+    <term name="illustrator">
+      <single>Illustrator</single>
+      <multiple>illustratoren</multiple>
+    </term>
+    <term name="translator">
+      <single>Übersetzer</single>
+      <multiple>Übersetzer</multiple>
+    </term>
+    <term name="editortranslator">
+      <single>Herausgeber &amp; Übersetzer</single>
+      <multiple>Herausgeber &amp; Übersetzer</multiple>
+    </term>
+
+    <!-- SHORT ROLE FORMS -->
+    <term name="director" form="short">
+      <single>Reg.</single>
+      <multiple>Reg..</multiple>
+    </term>
+    <term name="editor" form="short">
+      <single>Hrsg.</single>
+      <multiple>Hrsg.</multiple>
+    </term>
+    <term name="editorial-director" form="short">
+      <single>Hrsg.</single>
+      <multiple>Hrsg.</multiple>
+    </term>
+    <term name="illustrator" form="short">
+      <single>Ill.</single>
+      <multiple>Ill.</multiple>
+    </term>
+    <term name="translator" form="short">
+      <single>Übers.</single>
+      <multiple>Übers.</multiple>
+    </term>
+    <term name="editortranslator" form="short">
+      <single>Hrsg. &amp; Übers.</single>
+      <multiple>Hrsg. &amp; Übers</multiple>
+    </term>
+
+    <!-- VERB ROLE FORMS -->
+    <term name="director" form="verb">directed by</term>
+    <term name="editor" form="verb">herausgegeben von</term>
+    <term name="editorial-director" form="verb">herausgegeben von</term>
+    <term name="illustrator" form="verb">illustriert von</term>
+    <term name="interviewer" form="verb">interviewt von</term>
+    <term name="recipient" form="verb">an</term>
+    <term name="reviewed-author" form="verb">von</term>
+    <term name="translator" form="verb">übersetzt von</term>
+    <term name="editortranslator" form="verb">herausgegeben und übersetzt von</term>
+
+    <!-- SHORT VERB ROLE FORMS -->
+    <term name="container-author" form="verb-short">von</term>
+    <term name="director" form="verb-short">Reg.</term>
+    <term name="editor" form="verb-short">hg. von</term>
+    <term name="editorial-director" form="verb-short">hg. von</term>
+    <term name="illustrator" form="verb-short">illus. von</term>
+    <term name="translator" form="verb-short">übers. von</term>
+    <term name="editortranslator" form="verb-short">hg. &amp; übers. von</term>
+
+    <!-- LONG MONTH FORMS -->
+    <term name="month-01">Januar</term>
+    <term name="month-02">Februar</term>
+    <term name="month-03">März</term>
+    <term name="month-04">April</term>
+    <term name="month-05">Mai</term>
+    <term name="month-06">Juni</term>
+    <term name="month-07">Juli</term>
+    <term name="month-08">August</term>
+    <term name="month-09">September</term>
+    <term name="month-10">Oktober</term>
+    <term name="month-11">November</term>
+    <term name="month-12">Dezember</term>
+
+    <!-- SHORT MONTH FORMS -->
+    <term name="month-01" form="short">Jan.</term>
+    <term name="month-02" form="short">Feb.</term>
+    <term name="month-03" form="short">März</term>
+    <term name="month-04" form="short">Apr.</term>
+    <term name="month-05" form="short">Mai</term>
+    <term name="month-06" form="short">Juni</term>
+    <term name="month-07" form="short">Juli</term>
+    <term name="month-08" form="short">Aug.</term>
+    <term name="month-09" form="short">Sep.</term>
+    <term name="month-10" form="short">Okt.</term>
+    <term name="month-11" form="short">Nov.</term>
+    <term name="month-12" form="short">Dez.</term>
+
+    <!-- SEASONS -->
+    <term name="season-01">Frühjahr</term>
+    <term name="season-02">Sommer</term>
+    <term name="season-03">Herbst</term>
+    <term name="season-04">Winter</term>
+  </terms>
+</locale>

--- a/spec/fixtures/styles/apa-with-different-translations.csl
+++ b/spec/fixtures/styles/apa-with-different-translations.csl
@@ -37,6 +37,14 @@
       </term>
     </terms>
   </locale>
+  <locale xml:lang="fr">
+    <terms>
+      <term name="translator" form="short">
+        <single>le merveilleux traducteur</single>
+        <multiple>les traducteurs merveilleux</multiple>
+      </term>
+    </terms>
+  </locale>
   <macro name="container-contributors">
     <choose>
       <if type="chapter paper-conference" match="any">

--- a/spec/fixtures/styles/apa-with-different-translations.csl
+++ b/spec/fixtures/styles/apa-with-different-translations.csl
@@ -1,0 +1,443 @@
+<?xml version="1.0" encoding="utf-8"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" class="in-text" version="1.0" demote-non-dropping-particle="never">
+  <info>
+    <title>American Psychological Association 6th Edition</title>
+    <id>http://www.zotero.org/styles/apa-with-different-translations</id>
+    <link href="http://www.zotero.org/styles/apa-with-different-translations" rel="self"/>
+    <link href="http://owl.english.purdue.edu/owl/resource/560/01/" rel="documentation"/>
+    <author>
+      <name>Simon Kornblith</name>
+      <email>simon@simonster.com</email>
+    </author>
+    <contributor>
+      <name>Bruce D'Arcus</name>
+    </contributor>
+    <contributor>
+      <name>Curtis M. Humphrey</name>
+    </contributor>
+    <contributor>
+      <name>Richard Karnesky</name>
+      <email>karnesky+zotero@gmail.com</email>
+      <uri>http://arc.nucapt.northwestern.edu/Richard_Karnesky</uri>
+    </contributor>
+    <contributor>
+      <name>Sebastian Karcher</name>
+    </contributor>
+    <category field="psychology"/>
+    <category field="generic-base"/>
+    <category citation-format="author-date"/>
+    <updated>2010-01-27T20:08:03+00:00</updated>
+    <rights>This work is licensed under a Creative Commons Attribution-ShareAlike 3.0 License: http://creativecommons.org/licenses/by-sa/3.0/</rights>
+  </info>
+  <locale xml:lang="en">
+    <terms>
+      <term name="translator" form="short">
+        <single>Who translated this piece on her/his own</single>
+        <multiple>Who translated this piece together</multiple>
+      </term>
+    </terms>
+  </locale>
+  <macro name="container-contributors">
+    <choose>
+      <if type="chapter paper-conference" match="any">
+        <text term="in" text-case="capitalize-first" suffix=" "/>
+        <names variable="editor" delimiter=", " suffix=", ">
+          <name and="symbol" initialize-with=". " delimiter=", "/>
+          <label form="short" prefix=" (" text-case="capitalize-first" suffix=")"/>
+          <substitute>
+            <names variable="translator"/>
+          </substitute>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="secondary-contributors">
+    <choose>
+      <if type="chapter paper-conference" match="none">
+        <names variable="translator" delimiter=", " prefix=" (" suffix=")">
+          <name and="symbol" initialize-with=". " delimiter=", "/>
+          <label form="short" prefix=", " text-case="capitalize-first" suffix=""/>
+          <substitute>
+            <names variable="editor"/>
+          </substitute>
+        </names>
+      </if>
+    </choose>
+  </macro>
+  <macro name="author">
+    <names variable="author">
+      <name name-as-sort-order="all" and="symbol" sort-separator=", " initialize-with=". " delimiter=", " delimiter-precedes-last="always"/>
+      <label form="short" prefix=" (" suffix=".)" text-case="capitalize-first" strip-periods="true"/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="report">
+            <text variable="publisher"/>
+            <text macro="title"/>
+          </if>
+          <else>
+            <text macro="title"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="author-short">
+    <names variable="author">
+      <name form="short" and="symbol" delimiter=", " initialize-with=". "/>
+      <substitute>
+        <names variable="editor"/>
+        <names variable="translator"/>
+        <choose>
+          <if type="report">
+            <text variable="publisher"/>
+            <text variable="title" form="short" font-style="italic"/>
+          </if>
+          <else-if type="bill book graphic legal_case legislation motion_picture song" match="any">
+            <text variable="title" form="short" font-style="italic"/>
+          </else-if>
+          <else>
+            <text variable="title" form="short" quotes="true"/>
+          </else>
+        </choose>
+      </substitute>
+    </names>
+  </macro>
+  <macro name="access">
+    <choose>
+      <if type="thesis">
+        <choose>
+          <if variable="archive" match="any">
+            <group>
+              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+              <text term="from" suffix=" "/>
+              <text variable="archive" suffix="."/>
+              <text variable="archive_location" prefix=" (" suffix=")"/>
+            </group>
+          </if>
+          <else>
+            <group>
+              <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+              <text term="from" suffix=" "/>
+              <text variable="URL"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+      <else>
+        <choose>
+          <if variable="DOI">
+            <text variable="DOI" prefix="doi:"/>
+          </if>
+          <else>
+            <choose>
+              <if type="webpage">
+                <group delimiter=" ">
+                  <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+                  <group>
+                    <date variable="accessed" suffix=", ">
+                      <date-part name="month" suffix=" "/>
+                      <date-part name="day" suffix=", "/>
+                      <date-part name="year"/>
+                    </date>
+                  </group>
+                  <text term="from"/>
+                  <text variable="URL"/>
+                </group>
+              </if>
+              <else>
+                <group>
+                  <text term="retrieved" text-case="capitalize-first" suffix=" "/>
+                  <text term="from" suffix=" "/>
+                  <text variable="URL"/>
+                </group>
+              </else>
+            </choose>
+          </else>
+        </choose>
+      </else>
+    </choose>
+  </macro>
+  <macro name="title">
+    <choose>
+      <if type="report thesis" match="any">
+        <text variable="title" font-style="italic"/>
+        <group prefix=" (" suffix=")" delimiter=" ">
+          <text variable="genre"/>
+          <text variable="number" prefix="No. "/>
+        </group>
+      </if>
+      <else-if type="book graphic  motion_picture report song manuscript speech" match="any">
+        <text variable="title" font-style="italic"/>
+      </else-if>
+      <else>
+        <text variable="title"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="publisher">
+    <choose>
+      <if type="report" match="any">
+        <group delimiter=": ">
+          <text variable="publisher-place"/>
+          <text variable="publisher"/>
+        </group>
+      </if>
+      <else-if type="thesis" match="any">
+        <group delimiter=", ">
+          <text variable="publisher"/>
+          <text variable="publisher-place"/>
+        </group>
+      </else-if>
+      <else>
+        <group delimiter=", ">
+          <choose>
+            <if variable="event" match="none">
+              <text variable="genre"/>
+            </if>
+          </choose>
+          <choose>
+            <if type="article-journal article-magazine" match="none">
+              <group delimiter=": ">
+                <text variable="publisher-place"/>
+                <text variable="publisher"/>
+              </group>
+            </if>
+          </choose>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <macro name="event">
+    <choose>
+      <if variable="event">
+        <choose>
+          <if variable="genre" match="none">
+            <text term="presented at" text-case="capitalize-first" suffix=" "/>
+            <text variable="event"/>
+          </if>
+          <else>
+            <group delimiter=" ">
+              <text variable="genre" text-case="capitalize-first"/>
+              <text term="presented at"/>
+              <text variable="event"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issued">
+    <choose>
+      <if type="bill legal_case legislation" match="none">
+        <choose>
+          <if variable="issued">
+            <group prefix=" (" suffix=").">
+              <date variable="issued">
+                <date-part name="year"/>
+              </date>
+              <text variable="year-suffix"/>
+              <choose>
+                <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
+                  <date variable="issued">
+                    <date-part prefix=", " name="month"/>
+                    <date-part prefix=" " name="day"/>
+                  </date>
+                </if>
+              </choose>
+            </group>
+          </if>
+          <else>
+            <group prefix=" (" suffix=").">
+              <text term="no date" form="short"/>
+              <text variable="year-suffix" prefix="-"/>
+            </group>
+          </else>
+        </choose>
+      </if>
+    </choose>
+  </macro>
+  <macro name="issued-sort">
+    <choose>
+      <if type="article-journal bill book chapter graphic legal_case legislation motion_picture paper-conference report song" match="none">
+        <date variable="issued">
+          <date-part name="year"/>
+          <date-part name="month"/>
+          <date-part name="day"/>
+        </date>
+      </if>
+      <else>
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+      </else>
+    </choose>
+  </macro>
+  <macro name="issued-year">
+    <choose>
+      <if variable="issued">
+        <date variable="issued">
+          <date-part name="year"/>
+        </date>
+        <text variable="year-suffix"/>
+      </if>
+      <else>
+        <text term="no date" form="short"/>
+        <text variable="year-suffix" prefix="-"/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="edition">
+    <choose>
+      <if is-numeric="edition">
+        <group delimiter=" ">
+          <number variable="edition" form="ordinal"/>
+          <text term="edition" form="short" suffix="." strip-periods="true"/>
+        </group>
+      </if>
+      <else>
+        <text variable="edition" suffix="."/>
+      </else>
+    </choose>
+  </macro>
+  <macro name="locators">
+    <choose>
+      <if type="article-journal article-magazine" match="any">
+        <group prefix=", " delimiter=", ">
+          <group>
+            <text variable="volume" font-style="italic"/>
+            <text variable="issue" prefix="(" suffix=")"/>
+          </group>
+          <text variable="page"/>
+        </group>
+      </if>
+      <else-if type="article-newspaper">
+        <group delimiter=" " prefix=", ">
+          <label variable="page" form="short"/>
+          <text variable="page"/>
+        </group>
+      </else-if>
+      <else-if type="book graphic motion_picture report song chapter paper-conference" match="any">
+        <group prefix=" (" suffix=")" delimiter=", ">
+          <text macro="edition"/>
+          <group>
+            <text term="volume" form="short" plural="true" text-case="capitalize-first" suffix=". " strip-periods="true"/>
+            <number variable="number-of-volumes" form="numeric" prefix="1-"/>
+          </group>
+          <group>
+            <text term="volume" form="short" text-case="capitalize-first" suffix=". " strip-periods="true"/>
+            <number variable="volume" form="numeric"/>
+          </group>
+          <group>
+            <label variable="page" form="short" suffix=" "/>
+            <text variable="page"/>
+          </group>
+        </group>
+      </else-if>
+      <else-if type="legal_case">
+        <group prefix=" (" suffix=")" delimiter=" ">
+          <text variable="authority"/>
+          <date variable="issued" delimiter=" ">
+            <date-part name="month" form="short"/>
+            <date-part name="day" suffix=","/>
+            <date-part name="year"/>
+          </date>
+        </group>
+      </else-if>
+      <else-if type="bill legislation">
+        <date variable="issued" prefix=" (" suffix=")">
+          <date-part name="year"/>
+        </date>
+      </else-if>
+    </choose>
+  </macro>
+  <macro name="citation-locator">
+    <group>
+      <label variable="locator" form="short"/>
+      <text variable="locator" prefix=" "/>
+    </group>
+  </macro>
+  <macro name="container">
+    <choose>
+      <if type="bill legal_case legislation" match="none">
+        <text variable="container-title" font-style="italic"/>
+      </if>
+      <else>
+        <group delimiter=" " prefix=", ">
+          <choose>
+            <if variable="container-title">
+              <text variable="volume"/>
+              <text variable="container-title"/>
+              <group delimiter=" ">
+                <!--change to label variable="section" as that becomes available -->
+                <text term="section" form="symbol"/>
+                <text variable="section"/>
+              </group>
+              <text variable="page"/>
+            </if>
+            <else>
+              <choose>
+                <if type="legal_case">
+                  <text variable="number" prefix="No. "/>
+                </if>
+                <else>
+                  <text variable="number" prefix="Pub. L. No. "/>
+                  <group delimiter=" ">
+                    <!--change to label variable="section" as that becomes available -->
+                    <text term="section" form="symbol"/>
+                    <text variable="section"/>
+                  </group>
+                </else>
+              </choose>
+            </else>
+          </choose>
+        </group>
+      </else>
+    </choose>
+  </macro>
+  <citation et-al-min="6" et-al-use-first="1" et-al-subsequent-min="3" et-al-subsequent-use-first="1" disambiguate-add-year-suffix="true" disambiguate-add-names="true" disambiguate-add-givenname="true" collapse="year" givenname-disambiguation-rule="primary-name">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued-sort"/>
+    </sort>
+    <layout prefix="(" suffix=")" delimiter="; ">
+      <group delimiter=", ">
+        <text macro="author-short"/>
+        <text macro="issued-year"/>
+        <text macro="citation-locator"/>
+      </group>
+    </layout>
+  </citation>
+  <bibliography hanging-indent="true" et-al-min="8" et-al-use-first="7" entry-spacing="0" line-spacing="2">
+    <sort>
+      <key macro="author"/>
+      <key macro="issued-sort" sort="ascending"/>
+    </sort>
+    <layout>
+      <group suffix=".">
+        <group delimiter=". ">
+          <text macro="author"/>
+          <text macro="issued"/>
+        </group>
+        <group delimiter=". ">
+          <text macro="title" prefix=" "/>
+          <group>
+            <text macro="container-contributors"/>
+            <text macro="secondary-contributors"/>
+            <group delimiter=", ">
+              <text macro="container"/>
+              <text variable="collection-title"/>
+            </group>
+          </group>
+        </group>
+        <text macro="locators"/>
+        <group delimiter=", " prefix=". ">
+          <text macro="event"/>
+          <text macro="publisher"/>
+        </group>
+      </group>
+      <text macro="access" prefix=" "/>
+    </layout>
+  </bibliography>
+</style>


### PR DESCRIPTION
CSL style definitions can contain ``terms`` for any number of locales. Currently those terms are completely ignored in favor of the terms defined in a given locale.

This lets them take precedence over ``terms`` defined in a locales file. The locale's version acts as a fallback.

**We should test this in *real life* as good as we can. This MIGHT break a lot of citation styles**. We just do not know how many of those thousands of CSL styles do contain their own ``term`` definitions that differ from the locale (mostly ``en`` I guess) version. This PR would change the wording in all of them!

This is based on top off #1 